### PR TITLE
fix: use function parameter dynamo client instead of global one

### DIFF
--- a/api-integrations/src/get_orders/app.py
+++ b/api-integrations/src/get_orders/app.py
@@ -11,12 +11,12 @@ def fetch_all_orders(dynamo_client, table_name):
     last_evaluated_key = None
     while True:
         if last_evaluated_key:
-            response = ddb_client.scan(
+            response = dynamo_client.scan(
                 TableName=table_name,
                 ExclusiveStartKey=last_evaluated_key
             )
         else:
-            response = ddb_client.scan(TableName=table_name)
+            response = dynamo_client.scan(TableName=table_name)
             
         last_evaluated_key = response.get('LastEvaluatedKey')
 


### PR DESCRIPTION
*issue:* 

*Description of changes:*

I have changed the function `api-integrations/src/get_orders/app.fetch_all_orders` to use its parameter for dynamo db client instead of using the global one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
